### PR TITLE
Clarify add_webhook decorator return semantics

### DIFF
--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -151,13 +151,12 @@ class WebhooksServer:
             return self.add_webhook()(path)
 
         # Usage: provide a path. Example: `@app.add_webhook(...)`
-        @wraps(FastAPI.post)
-        def _inner_post(*args, **kwargs):
-            func = args[0]
+        def _inner_post(func: Callable) -> Callable:
             abs_path = f"/webhooks/{(path or func.__name__).strip('/')}"
             if abs_path in self.registered_webhooks:
                 raise ValueError(f"Webhook {abs_path} already exists.")
             self.registered_webhooks[abs_path] = func
+            return func
 
         return _inner_post
 

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -145,6 +145,7 @@ class TestWebhooksServerDontRun(unittest.TestCase):
             pass
 
         self.assertIn("/webhooks/handler", app.registered_webhooks)
+        self.assertIs(handler, app.registered_webhooks["/webhooks/handler"])
 
     def test_add_webhook_explicit_path(self):
         # Test adding a webhook
@@ -155,6 +156,18 @@ class TestWebhooksServerDontRun(unittest.TestCase):
             pass
 
         self.assertIn("/webhooks/test_webhook", app.registered_webhooks)  # still registered under /webhooks
+        self.assertIs(handler, app.registered_webhooks["/webhooks/test_webhook"])
+
+    def test_add_webhook_direct_call_returns_original_callable(self):
+        app = WebhooksServer()
+
+        async def handler():
+            return "ok"
+
+        returned = app.add_webhook(path="/callable")(handler)
+
+        self.assertIs(returned, handler)
+        self.assertIs(handler, app.registered_webhooks["/webhooks/callable"])
 
     def test_add_webhook_twice_should_fail(self):
         # Test adding a webhook


### PR DESCRIPTION
## Summary
- simplify `WebhooksServer.add_webhook` decorator to accept the target callable directly and return it unchanged after registration
- extend webhook server tests with a direct-call case to ensure the decorator hands back the original function reference

## Testing
- python -m pytest tests/test_webhooks_server.py -k "add_webhook"

------
https://chatgpt.com/codex/tasks/task_e_68dccfc9c6a08331ae7a5b6a9bb91da0