### PR TITLE
Add regression test for WebhooksServer decorator return

### DIFF
--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import unittest
 from unittest.mock import patch
 
@@ -146,6 +147,15 @@ class TestWebhooksServerDontRun(unittest.TestCase):
 
         self.assertIn("/webhooks/handler", app.registered_webhooks)
         self.assertIs(handler, app.registered_webhooks["/webhooks/handler"])
+
+    def test_add_webhook_decorator_returns_callable(self):
+        app = WebhooksServer()
+
+        @app.add_webhook
+        async def handler():
+            return "ok"
+
+        self.assertEqual(asyncio.run(handler()), "ok")
 
     def test_add_webhook_explicit_path(self):
         # Test adding a webhook


### PR DESCRIPTION
## Summary
- import asyncio in the webhook server test suite
- add coverage to ensure the add_webhook decorator keeps the original callable usable

## Testing
- python -m pytest tests/test_webhooks_server.py -k decorator_returns_callable *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dccc5f46188331945c981e60031fa2