### PR TITLE
Ensure add_webhook preserves original callable

### DIFF
--- a/src/huggingface_hub/_webhooks_server.py
+++ b/src/huggingface_hub/_webhooks_server.py
@@ -156,6 +156,7 @@ class WebhooksServer:
             if abs_path in self.registered_webhooks:
                 raise ValueError(f"Webhook {abs_path} already exists.")
             self.registered_webhooks[abs_path] = func
+            # Return the original callable so that decorating doesn't replace the symbol.
             return func
 
         return _inner_post

--- a/tests/test_webhooks_server.py
+++ b/tests/test_webhooks_server.py
@@ -163,10 +163,11 @@ class TestWebhooksServerDontRun(unittest.TestCase):
 
         @app.add_webhook(path="/test_webhook")
         async def handler():
-            pass
+            return "registered"
 
         self.assertIn("/webhooks/test_webhook", app.registered_webhooks)  # still registered under /webhooks
         self.assertIs(handler, app.registered_webhooks["/webhooks/test_webhook"])
+        self.assertEqual(asyncio.run(handler()), "registered")
 
     def test_add_webhook_direct_call_returns_original_callable(self):
         app = WebhooksServer()


### PR DESCRIPTION
## Summary
- ensure add_webhook explicitly returns the original callable after registration
- extend the explicit-path webhook test to assert the decorated function remains callable

## Testing
- pytest tests/test_webhooks_server.py::TestWebhooksServerDontRun::test_add_webhook_explicit_path -k TestWebhooksServerDontRun -q *(fails: missing fastapi dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e491321bdc83319575d50861cdd53a